### PR TITLE
fix: graceful HTTP server shutdown with in-flight request draining

### DIFF
--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -42,6 +42,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.Handler;
@@ -79,11 +81,15 @@ public abstract class Runner implements Runnable, AutoCloseable {
   public static final String UPCHECK_PATH = "/upcheck";
 
   private static final Logger LOG = LogManager.getLogger();
+  private static final long HTTP_SHUTDOWN_TIMEOUT_SECONDS = 20;
 
   protected final BaseConfig baseConfig;
 
   private HealthCheckHandler healthCheckHandler;
   private final List<Closeable> closeables = new ArrayList<>();
+  private final Object httpShutdownMonitor = new Object();
+  private final AtomicInteger inFlightHttpRequests = new AtomicInteger();
+  private volatile HttpServer httpServer;
 
   protected Runner(final BaseConfig baseConfig) {
     this.baseConfig = baseConfig;
@@ -179,7 +185,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
 
       populateRouter(context);
 
-      final HttpServer httpServer = createServerAndWait(vertx, router);
+      httpServer = createServerAndWait(vertx, router);
       final String tlsStatus = baseConfig.getTlsOptions().isPresent() ? "enabled" : "disabled";
       LOG.info(
           "Web3Signer has started with TLS {}, and ready to handle signing requests on {}:{}",
@@ -202,6 +208,79 @@ public abstract class Runner implements Runnable, AutoCloseable {
       LOG.error("Failed to initialise application", e);
       throw new InitializationException(e);
     }
+  }
+
+  private void gracefulHttpShutdown() {
+    waitForInFlightRequestsToComplete();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    httpServer.close(res -> latch.countDown());
+    try {
+      latch.await(HTTP_SHUTDOWN_TIMEOUT_SECONDS + 5, TimeUnit.SECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Interrupted while waiting for HTTP server to drain connections");
+    }
+  }
+
+  private void waitForInFlightRequestsToComplete() {
+    final long deadlineNanos =
+        System.nanoTime() + TimeUnit.SECONDS.toNanos(HTTP_SHUTDOWN_TIMEOUT_SECONDS);
+    synchronized (httpShutdownMonitor) {
+      while (inFlightHttpRequests.get() > 0) {
+        final long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          LOG.warn(
+              "Timed out waiting for {} in-flight HTTP request(s) to complete before shutdown",
+              inFlightHttpRequests.get());
+          return;
+        }
+        try {
+          TimeUnit.NANOSECONDS.timedWait(httpShutdownMonitor, remainingNanos);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          LOG.warn("Interrupted while waiting for in-flight HTTP requests to complete");
+          return;
+        }
+      }
+    }
+  }
+
+  private void decrementInFlightRequestCount() {
+    final int remainingRequests =
+        inFlightHttpRequests.updateAndGet(current -> Math.max(0, current - 1));
+    if (remainingRequests == 0) {
+      synchronized (httpShutdownMonitor) {
+        httpShutdownMonitor.notifyAll();
+      }
+    }
+  }
+
+  private Handler<HttpServerRequest> trackInFlightRequests(
+      final Handler<HttpServerRequest> requestHandler) {
+    return request -> {
+      inFlightHttpRequests.incrementAndGet();
+
+      final AtomicBoolean requestCompleted = new AtomicBoolean(false);
+      final Runnable completeRequest =
+          () -> {
+            if (requestCompleted.compareAndSet(false, true)) {
+              decrementInFlightRequestCount();
+            }
+          };
+
+      request.exceptionHandler(error -> completeRequest.run());
+      request.response().exceptionHandler(error -> completeRequest.run());
+      request.response().closeHandler(unused -> completeRequest.run());
+      request.response().endHandler(unused -> completeRequest.run());
+
+      try {
+        requestHandler.handle(request);
+      } catch (final RuntimeException | Error e) {
+        completeRequest.run();
+        throw e;
+      }
+    };
   }
 
   private void shutdownVertx(final Vertx vertx) {
@@ -286,7 +365,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
     final HttpServer httpServer = vertx.createHttpServer(tlsServerOptions);
     final CompletableFuture<Void> serverRunningFuture = new CompletableFuture<>();
     httpServer
-        .requestHandler(requestHandler)
+        .requestHandler(trackInFlightRequests(requestHandler))
         .listen(
             result -> {
               if (result.succeeded()) {
@@ -408,6 +487,13 @@ public abstract class Runner implements Runnable, AutoCloseable {
 
   @Override
   public void close() throws Exception {
+    if (httpServer != null) {
+      try {
+        gracefulHttpShutdown();
+      } catch (final Exception e) {
+        LOG.error("Failed to gracefully shut down HTTP server", e);
+      }
+    }
     for (Closeable closeable : closeables) {
       try {
         closeable.close();

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -89,6 +89,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
   private final List<Closeable> closeables = new ArrayList<>();
   private final Object httpShutdownMonitor = new Object();
   private final AtomicInteger inFlightHttpRequests = new AtomicInteger();
+  private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
   private volatile HttpServer httpServer;
 
   protected Runner(final BaseConfig baseConfig) {
@@ -211,6 +212,7 @@ public abstract class Runner implements Runnable, AutoCloseable {
   }
 
   private void gracefulHttpShutdown() {
+    shuttingDown.set(true);
     waitForInFlightRequestsToComplete();
 
     final CountDownLatch latch = new CountDownLatch(1);
@@ -259,6 +261,10 @@ public abstract class Runner implements Runnable, AutoCloseable {
   private Handler<HttpServerRequest> trackInFlightRequests(
       final Handler<HttpServerRequest> requestHandler) {
     return request -> {
+      if (shuttingDown.get()) {
+        request.response().setStatusCode(503).end();
+        return;
+      }
       inFlightHttpRequests.incrementAndGet();
 
       final AtomicBoolean requestCompleted = new AtomicBoolean(false);

--- a/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/Runner.java
@@ -212,13 +212,21 @@ public abstract class Runner implements Runnable, AutoCloseable {
   }
 
   private void gracefulHttpShutdown() {
-    shuttingDown.set(true);
+    // Set the flag under the monitor so that any thread currently inside the
+    // check-then-increment block in trackInFlightRequests will either see it
+    // before incrementing (and return 503) or will have already incremented
+    // and will be counted in the drain. This closes the TOCTOU window.
+    synchronized (httpShutdownMonitor) {
+      shuttingDown.set(true);
+    }
     waitForInFlightRequestsToComplete();
 
     final CountDownLatch latch = new CountDownLatch(1);
     httpServer.close(res -> latch.countDown());
     try {
-      latch.await(HTTP_SHUTDOWN_TIMEOUT_SECONDS + 5, TimeUnit.SECONDS);
+      if (!latch.await(HTTP_SHUTDOWN_TIMEOUT_SECONDS + 5, TimeUnit.SECONDS)) {
+        LOG.warn("Timed out waiting for HTTP server to close");
+      }
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       LOG.warn("Interrupted while waiting for HTTP server to drain connections");
@@ -261,11 +269,17 @@ public abstract class Runner implements Runnable, AutoCloseable {
   private Handler<HttpServerRequest> trackInFlightRequests(
       final Handler<HttpServerRequest> requestHandler) {
     return request -> {
-      if (shuttingDown.get()) {
-        request.response().setStatusCode(503).end();
-        return;
+      // Synchronize on httpShutdownMonitor so the shuttingDown check and the
+      // counter increment are atomic with respect to gracefulHttpShutdown().
+      // This prevents a request from slipping past the check after the drain
+      // has already seen counter=0 and begun closing the server.
+      synchronized (httpShutdownMonitor) {
+        if (shuttingDown.get()) {
+          request.response().setStatusCode(503).end();
+          return;
+        }
+        inFlightHttpRequests.incrementAndGet();
       }
-      inFlightHttpRequests.incrementAndGet();
 
       final AtomicBoolean requestCompleted = new AtomicBoolean(false);
       final Runnable completeRequest =

--- a/core/src/test/java/tech/pegasys/web3signer/core/RunnerGracefulShutdownTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/RunnerGracefulShutdownTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -240,8 +241,13 @@ class RunnerGracefulShutdownTest {
               }
             });
 
-    // Give close() time to enter its waiting state before releasing the request
-    Thread.sleep(300);
+    // Verify close() is actually blocking — it must not return while the request is in-flight
+    try {
+      closeFuture.get(200, TimeUnit.MILLISECONDS);
+      throw new AssertionError("close() returned immediately — it should have waited for the in-flight request");
+    } catch (final TimeoutException expected) {
+      // correct: close() is blocked waiting for the in-flight request
+    }
 
     // Release the in-flight request
     requestCanComplete.countDown();

--- a/core/src/test/java/tech/pegasys/web3signer/core/RunnerGracefulShutdownTest.java
+++ b/core/src/test/java/tech/pegasys/web3signer/core/RunnerGracefulShutdownTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.web3signer.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import tech.pegasys.web3signer.common.config.SignerLoaderConfig;
+import tech.pegasys.web3signer.core.config.BaseConfig;
+import tech.pegasys.web3signer.core.config.MetricsPushOptions;
+import tech.pegasys.web3signer.core.config.TlsOptions;
+import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
+
+import java.io.FileInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import io.vertx.core.Vertx;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RunnerGracefulShutdownTest {
+
+  @TempDir Path dataPath;
+
+  private static class StubBaseConfig implements BaseConfig {
+    private final Path dataPath;
+
+    StubBaseConfig(final Path dataPath) {
+      this.dataPath = dataPath;
+    }
+
+    @Override
+    public String getHttpListenHost() {
+      return "127.0.0.1";
+    }
+
+    @Override
+    public Integer getHttpListenPort() {
+      return 0;
+    }
+
+    @Override
+    public List<String> getHttpHostAllowList() {
+      return List.of("*");
+    }
+
+    @Override
+    public Collection<String> getCorsAllowedOrigins() {
+      return List.of();
+    }
+
+    @Override
+    public Path getDataPath() {
+      return dataPath;
+    }
+
+    @Override
+    public Path getKeyConfigPath() {
+      return dataPath;
+    }
+
+    @Override
+    public int getKeyStoreConfigFileMaxSize() {
+      return 104_857_600;
+    }
+
+    @Override
+    public Boolean isMetricsEnabled() {
+      return false;
+    }
+
+    @Override
+    public Integer getMetricsPort() {
+      return 0;
+    }
+
+    @Override
+    public String getMetricsNetworkInterface() {
+      return "127.0.0.1";
+    }
+
+    @Override
+    public Set<MetricCategory> getMetricCategories() {
+      return Set.of();
+    }
+
+    @Override
+    public List<String> getMetricsHostAllowList() {
+      return List.of();
+    }
+
+    @Override
+    public Optional<MetricsPushOptions> getMetricsPushOptions() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<TlsOptions> getTlsOptions() {
+      return Optional.empty();
+    }
+
+    @Override
+    public int getIdleConnectionTimeoutSeconds() {
+      return 30;
+    }
+
+    @Override
+    public void validateArgs() {}
+
+    @Override
+    public Boolean isAccessLogsEnabled() {
+      return false;
+    }
+
+    @Override
+    public int getVertxWorkerPoolSize() {
+      return 5;
+    }
+
+    @Override
+    public SignerLoaderConfig getSignerLoaderConfig() {
+      return SignerLoaderConfig.withDefaults(dataPath);
+    }
+
+    @Override
+    public long getReloadTimeoutMinutes() {
+      return 30L;
+    }
+  }
+
+  private static class TestRunner extends Runner {
+    private final Consumer<Context> routePopulator;
+
+    TestRunner(final BaseConfig config, final Consumer<Context> routePopulator) {
+      super(config);
+      this.routePopulator = routePopulator;
+    }
+
+    @Override
+    protected List<ArtifactSignerProvider> createArtifactSignerProvider(
+        final Vertx vertx, final MetricsSystem metricsSystem) {
+      return List.of();
+    }
+
+    @Override
+    protected void populateRouter(final Context context) {
+      routePopulator.accept(context);
+    }
+  }
+
+  private int readHttpPort() throws Exception {
+    final Path portsFile = dataPath.resolve("web3signer.ports");
+    final Properties props = new Properties();
+    try (final FileInputStream fis = new FileInputStream(portsFile.toFile())) {
+      props.load(fis);
+    }
+    return Integer.parseInt(props.getProperty("http-port"));
+  }
+
+  @Test
+  void closeWaitsForInFlightRequestBeforeShuttingDown() throws Exception {
+    final CountDownLatch requestStarted = new CountDownLatch(1);
+    final CountDownLatch requestCanComplete = new CountDownLatch(1);
+    final AtomicBoolean requestHandlerCompleted = new AtomicBoolean(false);
+
+    final TestRunner runner =
+        new TestRunner(
+            new StubBaseConfig(dataPath),
+            context ->
+                context
+                    .getRouter()
+                    .route("/slow")
+                    .blockingHandler(
+                        rc -> {
+                          requestStarted.countDown();
+                          try {
+                            requestCanComplete.await(10, TimeUnit.SECONDS);
+                          } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                          }
+                          requestHandlerCompleted.set(true);
+                          rc.response().setStatusCode(200).end("ok");
+                        }));
+
+    runner.run();
+    final int port = readHttpPort();
+
+    // Send a slow request that blocks in the handler until signalled
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            HttpClient.newHttpClient()
+                .send(
+                    HttpRequest.newBuilder()
+                        .uri(URI.create("http://127.0.0.1:" + port + "/slow"))
+                        .build(),
+                    HttpResponse.BodyHandlers.discarding());
+          } catch (final Exception ignored) {
+            // Connection may close during shutdown — expected
+          }
+        });
+
+    assertThat(requestStarted.await(5, TimeUnit.SECONDS))
+        .as("request handler should start within 5 seconds")
+        .isTrue();
+
+    // Trigger close in a separate thread — it should block until the in-flight request finishes
+    final CompletableFuture<Void> closeFuture =
+        CompletableFuture.runAsync(
+            () -> {
+              try {
+                runner.close();
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    // Give close() time to enter its waiting state before releasing the request
+    Thread.sleep(300);
+
+    // Release the in-flight request
+    requestCanComplete.countDown();
+
+    closeFuture.get(15, TimeUnit.SECONDS);
+
+    assertThat(requestHandlerCompleted.get())
+        .as("request handler must complete before close() returns")
+        .isTrue();
+  }
+
+  @Test
+  void closeCompletesNormallyWithNoInFlightRequests() throws Exception {
+    final TestRunner runner = new TestRunner(new StubBaseConfig(dataPath), context -> {});
+    runner.run();
+    runner.close();
+  }
+
+  @Test
+  void closeBeforeRunDoesNotThrow() throws Exception {
+    final TestRunner runner = new TestRunner(new StubBaseConfig(dataPath), context -> {});
+    runner.close();
+  }
+}


### PR DESCRIPTION
## PR Description

Adds graceful HTTP server shutdown to `Runner`. When `close()` is called, the server now waits for any in-flight HTTP requests to complete before closing the Vert.x `HttpServer`, preventing abrupt connection resets under load or during rolling restarts.

**Changes:**
- Added `trackInFlightRequests()` — wraps the request handler to atomically increment/decrement an in-flight counter, guarded against double-counting via `AtomicBoolean` per request
- Added `waitForInFlightRequestsToComplete()` — blocks the shutdown thread (up to 20 seconds) using `Object.wait`/`notifyAll` on a monitor
- Added `gracefulHttpShutdown()` — drains in-flight requests then closes the `HttpServer` via its async `close()` with a latch
- Modified `close()` to call `gracefulHttpShutdown()` before closing other resources
- `httpServer` promoted from local variable to `volatile` instance field so `close()` can reference it

## Fixed Issue(s)
<!-- No existing issue — this fixes a gap where shutdown could drop active requests -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

`RunnerGracefulShutdownTest` covers three scenarios using a real embedded Vert.x server:
1. `closeWaitsForInFlightRequestBeforeShuttingDown` — verifies `close()` blocks until a slow in-flight request completes before returning
2. `closeCompletesNormallyWithNoInFlightRequests` — verifies `close()` doesn't block when idle
3. `closeBeforeRunDoesNotThrow` — verifies the null-guard on `httpServer` is correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HTTP lifecycle and shutdown ordering for a signing service; bounded timeouts mean very long requests may still be cut off, but signing logic is unchanged.
> 
> **Overview**
> **`Runner.close()`** now drains active HTTP work before tearing down other resources, so rolling restarts and shutdown under load are less likely to reset connections mid-signing.
> 
> Shutdown sets a **`shuttingDown`** flag and wraps the Vert.x request handler with **`trackInFlightRequests`**, which counts in-flight requests, rejects new ones with **503** once shutdown has started, and decrements on response completion (with guards against double-counting). **`gracefulHttpShutdown`** waits up to **20 seconds** for the counter to reach zero, then closes the **`HttpServer`** asynchronously with a bounded wait. The server instance is stored on the runner so **`close()`** can run this path even when **`run()`** was never started (null-safe).
> 
> **`RunnerGracefulShutdownTest`** exercises blocking **`close()`** until a slow handler finishes, idle shutdown, and **`close()`** before **`run()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4bb5842af4072721332d0df5350b06efa08f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->