### PR TITLE
feat(eth1): optionally skip hashing sign payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming Release
 ### Features Added
 - Support for Hashicorp Vault Kubernetes authentication [PR 1195](https://github.com/Consensys/web3signer/pull/1195)
+- The eth1 signing endpoint (`POST /api/v1/eth1/sign/{identifier}`) accepts an optional `applyHash` field. It defaults to `true`, preserving the existing behaviour of applying Keccak-256 to `data` before signing. Setting it to `false` signs the caller-supplied `data` as a pre-computed digest, which must be exactly 32 bytes. Supported by file-based, AWS KMS and Azure Key Vault signers. [PR 1213](https://github.com/Consensys/web3signer/pull/1213)
 
 ### Bugs Fixed
 - Fix Key Manager API (`POST /eth/v1/keystores`) accepting a keystore whose JSON `pubkey` field does not match the decrypted private key. A mismatched import now returns `status: "error"` for that entry rather than poisoning the slashing-protection database under the claimed (unverified) pubkey.

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
@@ -150,6 +150,10 @@ public class Signer {
     if (applyHash != null) {
       requestBody.put("applyHash", applyHash);
     }
+    return eth1Sign(publicKey, requestBody);
+  }
+
+  public Response eth1Sign(final String publicKey, final JsonObject requestBody) {
     return given()
         .baseUri(getUrl())
         .contentType(ContentType.JSON)

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/dsl/signer/Signer.java
@@ -141,11 +141,20 @@ public class Signer {
   }
 
   public Response eth1Sign(final String publicKey, final Bytes dataToSign) {
+    return eth1Sign(publicKey, dataToSign, null);
+  }
+
+  public Response eth1Sign(
+      final String publicKey, final Bytes dataToSign, final Boolean applyHash) {
+    final JsonObject requestBody = new JsonObject().put("data", dataToSign.toHexString());
+    if (applyHash != null) {
+      requestBody.put("applyHash", applyHash);
+    }
     return given()
         .baseUri(getUrl())
         .contentType(ContentType.JSON)
         .pathParam("identifier", publicKey)
-        .body(new JsonObject().put("data", dataToSign.toHexString()).toString())
+        .body(requestBody.toString())
         .post(signPath(KeyType.SECP256K1));
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -43,6 +43,8 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariables;
+import org.web3j.crypto.Hash;
+import org.web3j.crypto.Sign;
 import org.web3j.crypto.Sign.SignatureData;
 
 public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
@@ -72,6 +74,39 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
         KeyType.SECP256K1);
 
     signAndVerifySignature();
+  }
+
+  @Test
+  public void signDigestWithFileBasedKeyWithoutHashing() throws URISyntaxException {
+    final String keyPath =
+        new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
+
+    METADATA_FILE_HELPERS.createKeyStoreYamlFileAt(
+        testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
+        Path.of(keyPath),
+        "pass",
+        KeyType.SECP256K1);
+    setupEth1Signer();
+
+    final Bytes digest = Bytes.wrap(Hash.sha3(DATA.toArray()));
+    final Response response = signer.eth1Sign(PUBLIC_KEY_HEX_STRING, digest, false);
+    final Bytes signature = verifyAndGetSignatureResponse(response);
+    verifyDigestSignature(signature, digest, PUBLIC_KEY_HEX_STRING);
+  }
+
+  @Test
+  public void rejectNonDigestWhenHashingIsDisabled() throws URISyntaxException {
+    final String keyPath =
+        new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
+
+    METADATA_FILE_HELPERS.createKeyStoreYamlFileAt(
+        testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
+        Path.of(keyPath),
+        "pass",
+        KeyType.SECP256K1);
+    setupEth1Signer();
+
+    assertThat(signer.eth1Sign(PUBLIC_KEY_HEX_STRING, DATA, false).statusCode()).isEqualTo(400);
   }
 
   @Test
@@ -198,6 +233,23 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
     final BigInteger messagePublicKey = recoverPublicKey(new SignatureData(v, r, s));
     assertThat(EthPublicKeyUtils.web3JPublicKeyToECPublicKey(messagePublicKey))
         .isEqualTo(expectedPublicKey);
+  }
+
+  void verifyDigestSignature(final Bytes signature, final Bytes digest, final String publicKeyHex) {
+    final ECPublicKey expectedPublicKey =
+        EthPublicKeyUtils.bytesToECPublicKey(Bytes.fromHexString(publicKeyHex));
+
+    final byte[] r = signature.slice(0, 32).toArray();
+    final byte[] s = signature.slice(32, 32).toArray();
+    final byte[] v = signature.slice(64).toArray();
+    try {
+      final BigInteger messagePublicKey =
+          Sign.signedMessageHashToKey(digest.toArray(), new SignatureData(v, r, s));
+      assertThat(EthPublicKeyUtils.web3JPublicKeyToECPublicKey(messagePublicKey))
+          .isEqualTo(expectedPublicKey);
+    } catch (final SignatureException e) {
+      throw new IllegalStateException("signature cannot be recovered", e);
+    }
   }
 
   private BigInteger recoverPublicKey(final SignatureData signature) {

--- a/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/web3signer/tests/signing/SecpSigningAcceptanceTest.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -64,28 +65,14 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
 
   @Test
   public void signDataWithFileBasedKey() throws URISyntaxException {
-    final String keyPath =
-        new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
-
-    METADATA_FILE_HELPERS.createKeyStoreYamlFileAt(
-        testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
-        Path.of(keyPath),
-        "pass",
-        KeyType.SECP256K1);
+    createFileBasedKeyStore();
 
     signAndVerifySignature();
   }
 
   @Test
   public void signDigestWithFileBasedKeyWithoutHashing() throws URISyntaxException {
-    final String keyPath =
-        new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
-
-    METADATA_FILE_HELPERS.createKeyStoreYamlFileAt(
-        testDirectory.resolve(PUBLIC_KEY_HEX_STRING + ".yaml"),
-        Path.of(keyPath),
-        "pass",
-        KeyType.SECP256K1);
+    createFileBasedKeyStore();
     setupEth1Signer();
 
     final Bytes digest = Bytes.wrap(Hash.sha3(DATA.toArray()));
@@ -96,6 +83,33 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
 
   @Test
   public void rejectNonDigestWhenHashingIsDisabled() throws URISyntaxException {
+    createFileBasedKeyStore();
+    setupEth1Signer();
+
+    assertThat(signer.eth1Sign(PUBLIC_KEY_HEX_STRING, DATA, false).statusCode()).isEqualTo(400);
+  }
+
+  @Test
+  public void rejectNonBooleanApplyHash() throws URISyntaxException {
+    createFileBasedKeyStore();
+    setupEth1Signer();
+
+    final JsonObject requestBody =
+        new JsonObject().put("data", DATA.toHexString()).put("applyHash", "false");
+    assertThat(signer.eth1Sign(PUBLIC_KEY_HEX_STRING, requestBody).statusCode()).isEqualTo(400);
+  }
+
+  @Test
+  public void rejectNullApplyHash() throws URISyntaxException {
+    createFileBasedKeyStore();
+    setupEth1Signer();
+
+    final JsonObject requestBody =
+        new JsonObject().put("data", DATA.toHexString()).putNull("applyHash");
+    assertThat(signer.eth1Sign(PUBLIC_KEY_HEX_STRING, requestBody).statusCode()).isEqualTo(400);
+  }
+
+  private void createFileBasedKeyStore() throws URISyntaxException {
     final String keyPath =
         new File(Resources.getResource("secp256k1/wallet.json").toURI()).getAbsolutePath();
 
@@ -104,9 +118,6 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
         Path.of(keyPath),
         "pass",
         KeyType.SECP256K1);
-    setupEth1Signer();
-
-    assertThat(signer.eth1Sign(PUBLIC_KEY_HEX_STRING, DATA, false).statusCode()).isEqualTo(400);
   }
 
   @Test
@@ -203,8 +214,12 @@ public class SecpSigningAcceptanceTest extends SigningAcceptanceTestBase {
           awsEndpointOverride,
           awsKeyId);
 
-      signAndVerifySignature(EthPublicKeyUtils.toHexString(ecPublicKey));
+      final String publicKeyHex = EthPublicKeyUtils.toHexString(ecPublicKey);
+      signAndVerifySignature(publicKeyHex);
 
+      final Bytes digest = Bytes.wrap(Hash.sha3(DATA.toArray()));
+      final Response digestResponse = signer.eth1Sign(publicKeyHex, digest, false);
+      verifyDigestSignature(verifyAndGetSignatureResponse(digestResponse), digest, publicKeyHex);
     } finally {
       awsKmsUtil.deleteKey(awsKeyId);
     }

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.plugin.services.metrics.OperationTimer.TimingContext
 public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
 
   private static final Logger LOG = LogManager.getLogger();
+  private static final int DIGEST_SIZE = 32;
   private final SignerForIdentifier signerForIdentifier;
   private final HttpApiMetrics metrics;
 
@@ -45,8 +46,14 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
     try (final TimingContext ignored = metrics.getSigningTimer().startTimer()) {
       final String identifier = routingContext.pathParam("identifier");
       final Bytes data;
+      final boolean applyHash;
       try {
         data = getDataToSign(routingContext.body());
+        applyHash = getApplyHash(routingContext.body());
+        if (!applyHash && data.size() != DIGEST_SIZE) {
+          throw new IllegalArgumentException(
+              "Data must be exactly 32 bytes when 'applyHash' is false");
+        }
       } catch (final RuntimeException e) {
         metrics.getMalformedRequestCounter().inc();
         LOG.debug("Invalid signing request", e);
@@ -55,7 +62,7 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
       }
 
       signerForIdentifier
-          .sign(normaliseIdentifier(identifier), data)
+          .sign(normaliseIdentifier(identifier), data, applyHash)
           .ifPresentOrElse(
               signature -> respondWithSignature(routingContext, signature),
               () -> {
@@ -81,5 +88,9 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
     }
 
     return Bytes.fromHexString(jsonObject.getString("data"));
+  }
+
+  private boolean getApplyHash(final RequestBody requestBody) {
+    return requestBody.asJsonObject().getBoolean("applyHash", true);
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/Eth1SignForIdentifierHandler.java
@@ -20,7 +20,6 @@ import tech.pegasys.web3signer.core.service.http.metrics.HttpApiMetrics;
 
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -48,8 +47,9 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
       final Bytes data;
       final boolean applyHash;
       try {
-        data = getDataToSign(routingContext.body());
-        applyHash = getApplyHash(routingContext.body());
+        final JsonObject requestBody = routingContext.body().asJsonObject();
+        data = getDataToSign(requestBody);
+        applyHash = getApplyHash(requestBody);
         if (!applyHash && data.size() != DIGEST_SIZE) {
           throw new IllegalArgumentException(
               "Data must be exactly 32 bytes when 'applyHash' is false");
@@ -77,9 +77,7 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
     routingContext.response().putHeader(CONTENT_TYPE, TEXT_PLAIN_UTF_8).end(signature);
   }
 
-  private Bytes getDataToSign(final RequestBody requestBody) {
-    final JsonObject jsonObject = requestBody.asJsonObject();
-
+  private Bytes getDataToSign(final JsonObject jsonObject) {
     if (!jsonObject.containsKey("data")) {
       throw new IllegalArgumentException("Request must contain a 'data' field");
     }
@@ -90,7 +88,14 @@ public class Eth1SignForIdentifierHandler implements Handler<RoutingContext> {
     return Bytes.fromHexString(jsonObject.getString("data"));
   }
 
-  private boolean getApplyHash(final RequestBody requestBody) {
-    return requestBody.asJsonObject().getBoolean("applyHash", true);
+  private boolean getApplyHash(final JsonObject jsonObject) {
+    if (!jsonObject.containsKey("applyHash")) {
+      return true;
+    }
+    final Boolean applyHash = jsonObject.getBoolean("applyHash");
+    if (applyHash == null) {
+      throw new IllegalArgumentException("Field 'applyHash' must not be null");
+    }
+    return applyHash;
   }
 }

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/SignerForIdentifier.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/SignerForIdentifier.java
@@ -13,6 +13,7 @@
 package tech.pegasys.web3signer.core.service.http.handlers.signing;
 
 import tech.pegasys.web3signer.signing.ArtifactSignerProvider;
+import tech.pegasys.web3signer.signing.EthSecpArtifactSigner;
 
 import java.util.Optional;
 
@@ -40,6 +41,21 @@ public class SignerForIdentifier {
    */
   public Optional<String> sign(final String identifier, final Bytes data) {
     return signerProvider.getSigner(identifier).map(signer -> signer.sign(data).asHex());
+  }
+
+  /**
+   * Sign data for a given identifier with a request-specific hashing preference.
+   *
+   * @param identifier The identifier for which to sign data.
+   * @param data Data to sign.
+   * @param applyHash Whether to apply Keccak-256 before signing.
+   * @return Optional String of signature (in hex format). Empty if no signer is available.
+   */
+  public Optional<String> sign(final String identifier, final Bytes data, final boolean applyHash) {
+    return signerProvider
+        .getSigner(identifier)
+        .map(EthSecpArtifactSigner.class::cast)
+        .map(signer -> signer.sign(data, applyHash).asHex());
   }
 
   /**

--- a/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/SignerForIdentifier.java
+++ b/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/SignerForIdentifier.java
@@ -50,12 +50,23 @@ public class SignerForIdentifier {
    * @param data Data to sign.
    * @param applyHash Whether to apply Keccak-256 before signing.
    * @return Optional String of signature (in hex format). Empty if no signer is available.
+   * @throws UnsupportedOperationException if applyHash is false and the resolved signer cannot sign
+   *     a pre-computed digest.
    */
   public Optional<String> sign(final String identifier, final Bytes data, final boolean applyHash) {
     return signerProvider
         .getSigner(identifier)
-        .map(EthSecpArtifactSigner.class::cast)
-        .map(signer -> signer.sign(data, applyHash).asHex());
+        .map(
+            signer -> {
+              if (signer instanceof EthSecpArtifactSigner ethSecpSigner) {
+                return ethSecpSigner.sign(data, applyHash).asHex();
+              }
+              if (!applyHash) {
+                throw new UnsupportedOperationException(
+                    "Signer for identifier does not support signing a pre-computed digest");
+              }
+              return signer.sign(data).asHex();
+            });
   }
 
   /**

--- a/openapi-specs/eth1/web3signer.yaml
+++ b/openapi-specs/eth1/web3signer.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: 'Web3Signer ETH1 API'
   description: 'Sign ETH1 Artifacts'
-  version: '1.1.1'
+  version: '1.2.0'
   license:
     name: 'Apache 2.0'
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
@@ -41,6 +41,8 @@ paths:
                   description: 'Whether to apply Keccak-256 to data before signing. If false, data must be exactly 32 bytes.'
               required:
                 - data
+              additionalProperties:
+                type: string
             example:
               data: 0x48656c6c6f2c20776f726c6421
               applyHash: true

--- a/openapi-specs/eth1/web3signer.yaml
+++ b/openapi-specs/eth1/web3signer.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: 'Web3Signer ETH1 API'
   description: 'Sign ETH1 Artifacts'
-  version: '1.1.0'
+  version: '1.1.1'
   license:
     name: 'Apache 2.0'
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
@@ -17,7 +17,7 @@ paths:
       tags:
         - 'Signing'
       summary: 'Signs data for ETH1 SECP256K1 public key'
-      description: 'Signs data for the ETH1 SECP256K1 public key specified as part of the URL and returns the signature'
+      description: 'Signs data for the ETH1 SECP256K1 public key specified as part of the URL and returns the signature. By default, Web3Signer applies Keccak-256 to the data before signing. Set applyHash to false to sign a caller-supplied 32-byte digest as-is.'
       operationId: 'ETH1_SIGN'
       parameters:
         - name: 'identifier'
@@ -35,12 +35,15 @@ paths:
               properties:
                 data:
                   type: string
+                applyHash:
+                  type: boolean
+                  default: true
+                  description: 'Whether to apply Keccak-256 to data before signing. If false, data must be exactly 32 bytes.'
               required:
                 - data
-              additionalProperties:
-                type: string
             example:
               data: 0x48656c6c6f2c20776f726c6421
+              applyHash: true
 
       responses:
         '200':

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/EthSecpArtifactSigner.java
@@ -38,6 +38,10 @@ public class EthSecpArtifactSigner implements ArtifactSigner {
     return new SecpArtifactSignature(signer.sign(message.toArray()));
   }
 
+  public SecpArtifactSignature sign(final Bytes message, final boolean applyHash) {
+    return new SecpArtifactSignature(signer.sign(message.toArray(), applyHash));
+  }
+
   @Override
   public KeyType getKeyType() {
     return KeyType.SECP256K1;

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/Signer.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/Signer.java
@@ -18,5 +18,7 @@ public interface Signer {
 
   Signature sign(final byte[] data);
 
+  Signature sign(final byte[] data, final boolean applyHash);
+
   ECPublicKey getPublicKey();
 }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/aws/AwsKmsSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/aws/AwsKmsSigner.java
@@ -40,6 +40,7 @@ public class AwsKmsSigner implements Signer {
 
   @Override
   public Signature sign(final byte[] data) {
+    // sha3hash is required for eth1 signing. Filecoin signing doesn't need hashing.
     return sign(data, applySha3Hash);
   }
 

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/aws/AwsKmsSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/aws/AwsKmsSigner.java
@@ -40,8 +40,12 @@ public class AwsKmsSigner implements Signer {
 
   @Override
   public Signature sign(final byte[] data) {
-    // sha3hash is required for eth1 signing. Filecoin signing doesn't need hashing.
-    final byte[] dataToSign = applySha3Hash ? Hash.sha3(data) : data;
+    return sign(data, applySha3Hash);
+  }
+
+  @Override
+  public Signature sign(final byte[] data, final boolean applyHash) {
+    final byte[] dataToSign = applyHash ? Hash.sha3(data) : data;
     final byte[] signature = awsKmsClient.sign(kmsKeyId, dataToSign);
     return Eth1SignatureUtil.deriveSignatureFromDerEncoded(dataToSign, ecPublicKey, signature);
   }

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/azure/AzureKeyVaultSigner.java
@@ -63,8 +63,12 @@ public class AzureKeyVaultSigner implements Signer {
 
   @Override
   public Signature sign(byte[] data) {
+    return sign(data, needsToHash);
+  }
 
-    final byte[] dataToSign = needsToHash ? Hash.sha3(data) : data;
+  @Override
+  public Signature sign(final byte[] data, final boolean applyHash) {
+    final byte[] dataToSign = applyHash ? Hash.sha3(data) : data;
 
     // TODO - We can use the sign method from the azure library again once they fix the issue with
     // the SECP256K1 for java 17

--- a/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSigner.java
+++ b/signing/src/main/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSigner.java
@@ -42,7 +42,12 @@ public class CredentialSigner implements Signer {
 
   @Override
   public Signature sign(final byte[] data) {
-    final SignatureData signature = Sign.signMessage(data, credentials.getEcKeyPair(), needToHash);
+    return sign(data, needToHash);
+  }
+
+  @Override
+  public Signature sign(final byte[] data, final boolean applyHash) {
+    final SignatureData signature = Sign.signMessage(data, credentials.getEcKeyPair(), applyHash);
     return new Signature(
         new BigInteger(signature.getV()),
         new BigInteger(1, signature.getR()),

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/EthSecpArtifactSignerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/EthSecpArtifactSignerTest.java
@@ -22,6 +22,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.Credentials;
 import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Hash;
 import org.web3j.crypto.Sign;
 import org.web3j.crypto.Sign.SignatureData;
 import org.web3j.utils.Numeric;
@@ -54,6 +55,25 @@ class EthSecpArtifactSignerTest {
     final SecpArtifactSignature signature = ethSecpArtifactSigner.sign(message);
 
     final SignatureData expectedSignature = Sign.signMessage(message.toArrayUnsafe(), ecKeyPair);
+    final Signature signatureData = signature.getSignatureData();
+    assertThat(signatureData.getR()).isEqualTo(Numeric.toBigInt(expectedSignature.getR()));
+    assertThat(signatureData.getS()).isEqualTo(Numeric.toBigInt(expectedSignature.getS()));
+    assertThat(signatureData.getV()).isEqualTo(Numeric.toBigInt(expectedSignature.getV()));
+  }
+
+  @Test
+  void signsDigestWithoutHashing() {
+    final ECKeyPair ecKeyPair =
+        new ECKeyPair(Numeric.toBigInt(PRIVATE_KEY), Numeric.toBigInt(PUBLIC_KEY));
+    final Credentials credentials = Credentials.create(ecKeyPair);
+    final EthSecpArtifactSigner ethSecpArtifactSigner =
+        new EthSecpArtifactSigner(new CredentialSigner(credentials));
+
+    final Bytes digest = Bytes.wrap(Hash.sha3("Hello, world!".getBytes(UTF_8)));
+    final SecpArtifactSignature signature = ethSecpArtifactSigner.sign(digest, false);
+
+    final SignatureData expectedSignature =
+        Sign.signMessage(digest.toArrayUnsafe(), ecKeyPair, false);
     final Signature signatureData = signature.getSignatureData();
     assertThat(signatureData.getR()).isEqualTo(Numeric.toBigInt(expectedSignature.getR()));
     assertThat(signatureData.getS()).isEqualTo(Numeric.toBigInt(expectedSignature.getS()));

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
@@ -43,11 +43,17 @@ class CredentialSignerTest {
   @Test
   void requestHashFlagOverridesSignerDefault() {
     final Credentials credentials = Credentials.create(ECKeyPair.create(BigInteger.ONE));
-    final CredentialSigner signer = new CredentialSigner(credentials);
-    final byte[] data = "Hello World".getBytes(UTF_8);
 
-    assertThat(signer.sign(data, true))
+    final CredentialSigner hashingSigner = new CredentialSigner(credentials);
+    final CredentialSigner nonHashingSigner = new CredentialSigner(credentials, false);
+
+    final byte[] digest = Hash.sha3("Hello World".getBytes(UTF_8));
+
+    assertThat(hashingSigner.sign(digest, false))
         .usingRecursiveComparison()
-        .isEqualTo(signer.sign(Hash.sha3(data), false));
+        .isEqualTo(nonHashingSigner.sign(digest));
+    assertThat(nonHashingSigner.sign(digest, true))
+        .usingRecursiveComparison()
+        .isEqualTo(hashingSigner.sign(digest));
   }
 }

--- a/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
+++ b/signing/src/test/java/tech/pegasys/web3signer/signing/secp256k1/filebased/CredentialSignerTest.java
@@ -39,4 +39,15 @@ class CredentialSignerTest {
         .usingRecursiveComparison()
         .isEqualTo(nonHashingSigner.sign(Hash.sha3(data)));
   }
+
+  @Test
+  void requestHashFlagOverridesSignerDefault() {
+    final Credentials credentials = Credentials.create(ECKeyPair.create(BigInteger.ONE));
+    final CredentialSigner signer = new CredentialSigner(credentials);
+    final byte[] data = "Hello World".getBytes(UTF_8);
+
+    assertThat(signer.sign(data, true))
+        .usingRecursiveComparison()
+        .isEqualTo(signer.sign(Hash.sha3(data), false));
+  }
 }


### PR DESCRIPTION
- add optional `applyHash` to ETH1 signing requests, defaulting to `true`
- support signing raw 32-byte digests with local, AWS KMS, and Azure signers
- document and test the new behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ETH1 signing semantics for callers that set `applyHash: false` (wrong digest length or misuse could produce invalid signatures), though default behavior is unchanged. Touches core signing and remote KMS/Azure paths.
> 
> **Overview**
> Adds an optional **`applyHash`** field on `POST /api/v1/eth1/sign/{identifier}` (OpenAPI **1.2.0**). It defaults to **`true`**, so existing clients still get Keccak-256 over `data` before signing. With **`applyHash: false`**, Web3Signer signs the supplied **`data` as a 32-byte digest** with no extra hash; non-32-byte payloads return **400**.
> 
> The HTTP handler parses and validates `applyHash` (rejects null or non-boolean), and **`SignerForIdentifier`** forwards the flag into **`EthSecpArtifactSigner`**. SECP **`Signer`** implementations (file-based, **AWS KMS**, **Azure Key Vault**) gain **`sign(data, applyHash)`** so per-request hashing can override signer defaults. Other signer types with `applyHash: false` raise **`UnsupportedOperationException`**.
> 
> Acceptance and unit tests cover digest signing, validation errors, and AWS KMS digest paths; the changelog documents the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401d171476417817a37cafb943f68da235f05ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->