### PR TITLE
Rotate changelog for upcoming release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Upcoming Release
+### Features Added
+
+### Bugs Fixed
+
+
+---
 ## 26.7.0
 ### Features Added
 - Support for Hashicorp Vault Kubernetes authentication [PR 1195](https://github.com/Consensys/web3signer/pull/1195)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Rotate changelog for upcoming release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog structure change with no runtime or build impact.
> 
> **Overview**
> Adds a new **Upcoming Release** section at the top of `CHANGELOG.md` with empty **Features Added** and **Bugs Fixed** placeholders, plus a horizontal rule before the **26.7.0** entry. This is the usual pre-release housekeeping so new notes can accumulate under **Upcoming Release** without editing the shipped **26.7.0** block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b657d1b15ee9e1893dff86321f4d35d2dac3805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->