### PR TITLE
Update ConsenSys/github-actions to Consensys-Incorporated

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -30,13 +30,13 @@ jobs:
 
       - name: Setup Java and Gradle
         id: setup-java-gradle
-        uses: ConsenSys/github-actions/java-setup-gradle@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
+        uses: Consensys-Incorporated/github-actions/java-setup-gradle@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
         with:
           VERSION: '25'
 
       - name: Determine Web3Signer version
         id: project-version
-        uses: ConsenSys/github-actions/java-get-project-version@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
+        uses: Consensys-Incorporated/github-actions/java-get-project-version@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
 
       # v3
       - name: Authenticate to Google Cloud

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Run renovatebot
-        uses: ConsenSys/github-actions/renovatebot@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
+        uses: Consensys-Incorporated/github-actions/renovatebot@31dbb917dd78b1dc18b4838a2d7d598b359b834f # main
         with:
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_PRIVATE_KEY: ${{ secrets.GH_PRIVATE_KEY }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/web3signer/blob/master/CONTRIBUTING.md -->

## PR Description
Update GitHub Actions org references from `ConsenSys/github-actions` to `Consensys-Incorporated/github-actions` across workflows (`ci_main.yml` and `renovatebot.yml`).

## Fixed Issue(s)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [x] I thought about testing these changes in a realistic/non-local environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only owner string updates with identical action SHAs; risk is limited to CI failing if the new org/repo is inaccessible.
> 
> **Overview**
> Updates CI to pull shared composite actions from **`Consensys-Incorporated/github-actions`** instead of **`ConsenSys/github-actions`**, matching an org/repo rename.
> 
> In **`ci_main.yml`**, the **Setup Java and Gradle** and **Determine Web3Signer version** steps now use the new owner; **`renovatebot.yml`** does the same for the Renovate step. Action paths and pinned SHAs (`31dbb917…`) are unchanged—only the organization slug in the `uses:` URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b9e11fe342a97d21cdef18f4180f3aa834f4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->